### PR TITLE
Allow a negative "delta" in the add_working_days method

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,8 @@ CHANGELOG
 - Germany calendar added, thx to @rndusr
 - Support building on systems where LANG=C (Ubuntu) #92
 - little improvement to directly return a tested value.
+- ``delta`` argument for ``add_working_days()`` can be negative. added a
+  ``sub_working_days()`` method that computes working days backwards.
 - BUGFIX: shifting UK boxing day if Christmas day falls on a Friday (shit to
   next Monday) #95
 - BUGFIX: Renaming the Finnish "Independance Day" #101 (thx to

--- a/workalendar/core.py
+++ b/workalendar/core.py
@@ -125,8 +125,10 @@ class Calendar(object):
         """
         days = 0
         temp_day = day
+        day_added = 1 if delta >= 0 else -1
+        delta = abs(delta)
         while days < delta:
-            temp_day = temp_day + timedelta(days=1)
+            temp_day = temp_day + timedelta(days=day_added)
             if self.is_working_day(temp_day,
                                    extra_working_days=extra_working_days,
                                    extra_holidays=extra_holidays):

--- a/workalendar/core.py
+++ b/workalendar/core.py
@@ -114,6 +114,10 @@ class Calendar(object):
                          extra_working_days=None, extra_holidays=None):
         """Add `delta` working days to the date.
 
+        the ``delta`` parameter might be positive or negative. If it's
+        negative, you may want to use the ``sub_working_days()`` method with
+        a positive ``delta`` argument.
+
         By providing ``extra_working_days``, you'll state that these dates
         **are** working days.
 
@@ -134,6 +138,30 @@ class Calendar(object):
                                    extra_holidays=extra_holidays):
                 days += 1
         return temp_day
+
+    def sub_working_days(self, day, delta,
+                         extra_working_days=None, extra_holidays=None):
+        """
+        Substract `delta` working days to the date.
+
+        This method is a shortcut / helper. Users may want to use either::
+
+            cal.add_working_days(my_date, -7)
+            cal.sub_working_days(my_date, 7)
+
+        The other parameters are to be used exactly as in the
+        ``add_working_days`` method.
+
+        A negative ``delta`` argument will be converted into its absolute
+        value. Hence, the two following calls are equivalent::
+
+            cal.sub_working_days(my_date, -7)
+            cal.sub_working_days(my_date, 7)
+
+        """
+        delta = abs(delta)
+        return self.add_working_days(
+            day, -delta, extra_working_days, extra_holidays)
 
     def find_following_working_day(self, day):
         "Looks for the following working day"

--- a/workalendar/tests/test_core.py
+++ b/workalendar/tests/test_core.py
@@ -207,6 +207,15 @@ class MockCalendarTest(GenericCalendarTest):
             self.cal.add_working_days(day, -7),
             date(self.year - 1, 12, 26)
         )
+        self.assertEquals(
+            self.cal.sub_working_days(day, 7),
+            date(self.year - 1, 12, 26)
+        )
+        # Negative argument to sub_working_days -> converted to positive.
+        self.assertEquals(
+            self.cal.sub_working_days(day, -7),
+            date(self.year - 1, 12, 26)
+        )
 
 
 class IslamicMixinTest(GenericCalendarTest):

--- a/workalendar/tests/test_core.py
+++ b/workalendar/tests/test_core.py
@@ -200,6 +200,14 @@ class MockCalendarTest(GenericCalendarTest):
         self.assertFalse(
             self.cal.is_working_day(datetime(2014, 1, 1)))
 
+    def test_add_working_days_backwards(self):
+        day = date(self.year, 1, 3)
+        # since this calendar has no weekends, we'll just have a 1-day-shift
+        self.assertEquals(
+            self.cal.add_working_days(day, -7),
+            date(self.year - 1, 12, 26)
+        )
+
 
 class IslamicMixinTest(GenericCalendarTest):
     cal_class = IslamicMixin


### PR DESCRIPTION
To be able to compute working days backwards, from a "target date" to a "start date".