### PR TITLE
Fix name of Pentecost in Sweden

### DIFF
--- a/workalendar/europe.py
+++ b/workalendar/europe.py
@@ -52,7 +52,7 @@ class Sweden(WesternCalendar, ChristianMixin):
     include_easter_monday = True
     include_ascension = True
     include_whit_sunday = True
-    whit_sunday_abel = "Pentecost"
+    whit_sunday_label = "Pentecost"
     # Christmas Eve is not a holiday but not a work day either
     include_christmas_eve = True
     include_boxing_day = True

--- a/workalendar/tests/test_europe.py
+++ b/workalendar/tests/test_europe.py
@@ -129,6 +129,10 @@ class SwedenTest(GenericCalendarTest):
         self.assertIn(date(2015, 12, 26), holidays)  # second day of xmas
         self.assertIn(date(2015, 12, 31), holidays)  # new year's eve
 
+    def test_pentecost(self):
+        holidays = self.cal.holidays(2015)
+        self.assertIn((date(2015, 5, 24), 'Pentecost'), holidays)
+
 
 class FinlandTest(GenericCalendarTest):
     cal_class = Finland


### PR DESCRIPTION
There was a naming error making Pentecost be called Whit Sunday in Sweden (not that any Swedes would know the English word for it anyway).